### PR TITLE
Fix prime set status issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prime-parts-plat-scanner",
-  "version": "1.16.1",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prime-parts-plat-scanner",
-      "version": "1.16.1",
+      "version": "1.16.3",
       "dependencies": {
         "@google/generative-ai": "^0.2.1",
         "@supabase/supabase-js": "^2.50.2",

--- a/src/components/PrimeSetsSection.tsx
+++ b/src/components/PrimeSetsSection.tsx
@@ -314,6 +314,23 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
     } else if (newState === 'owned') {
       removeFromBuildPlan(setName); // Remove from plan if it was planned
       toggleSetMastery(setId); // Mark as mastered
+      
+      // IMMEDIATE STATE UPDATE - Fix for owned status bug
+      setSetProgress(prev => prev.map(p => 
+        p.set.id === setId 
+          ? { ...p, ismastered: true }
+          : p
+      ));
+    }
+
+    // Clear previous state for transitions from 'owned'
+    if (currentState === 'owned' && newState !== 'owned') {
+      // Immediate state update when removing mastery
+      setSetProgress(prev => prev.map(p => 
+        p.set.id === setId 
+          ? { ...p, ismastered: false }
+          : p
+      ));
     }
 
     // Update local state


### PR DESCRIPTION
Fix Prime Set 'owned' status reverting due to state synchronization issue.

Previously, setting a Prime Set to 'owned' would update localStorage but not immediately update the React component's state. This led to a race condition where the UI would re-render with stale data, causing the status to revert to 'buildable'. This PR adds immediate state updates to `setSetProgress` to ensure the UI reflects the correct 'owned' status instantly.