### PR TITLE
Scan and sort syndicate rewards by value

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A powerful AI-powered tool that scans Warframe Prime parts inventory screenshots
 - 🖼️ **Multi-Image Support**: Process multiple inventory screenshots at once
 - 🔄 **Smart Refresh System**: Update prices without re-uploading screenshots
 - 📦 **Persistent Inventory**: Your scanned items save automatically across sessions
-- 🎮 **Extended Item Support**: Scan both Prime Parts and Void Relics
+- 🎮 **Extended Item Support**: Scan Prime Parts, Void Relics, and Syndicate Rewards
+- 🛡️ **Syndicate Market Analysis**: Compare plat/standing ratios to optimize standing spending
 - 📱 **Mobile-First Design**: Optimized interface with touch-friendly controls
 - 🎨 **Warframe-Themed UI**: Beautiful interface matching the game's aesthetic
 - ⚡ **Reliable Processing**: Robust queue system with automatic error handling
@@ -36,7 +37,13 @@ A powerful AI-powered tool that scans Warframe Prime parts inventory screenshots
 - Remove individual items or clear entire categories
 - Click item names to view detailed market listings on Warframe Market
 
-### 4. Cloud Sync (Optional)
+### 4. Syndicate Rewards Analysis
+- View all syndicate rewards with current market prices
+- Sort by plat/standing ratio to find the best value items
+- Filter by syndicate, item type, price range, and standing cost
+- Compare different syndicates to optimize your standing spending
+
+### 5. Cloud Sync (Optional)
 - Enable cross-platform synchronization in Settings > Cloud Sync
 - Your inventory, build plans, and progress sync across all devices
 - Uses your Gemini API key as a secure unique identifier

--- a/public/syndicate-rewards.json
+++ b/public/syndicate-rewards.json
@@ -1,0 +1,475 @@
+{
+  "syndicates": [
+    {
+      "name": "Steel Meridian",
+      "rewards": [
+        {
+          "id": "steel_meridian_hema",
+          "name": "Hema",
+          "category": "syndicate_rewards",
+          "syndicate": "Steel Meridian",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "steel_meridian_justice_blades",
+          "name": "Justice Blades",
+          "category": "syndicate_rewards",
+          "syndicate": "Steel Meridian",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "steel_meridian_red_veil_specter",
+          "name": "Red Veil Specter Blueprint",
+          "category": "syndicate_rewards",
+          "syndicate": "Steel Meridian",
+          "standingCost": 5000,
+          "itemType": "other",
+          "status": "loading"
+        },
+        {
+          "id": "steel_meridian_justice",
+          "name": "Justice",
+          "category": "syndicate_rewards",
+          "syndicate": "Steel Meridian",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "steel_meridian_steel_meridian_sigil",
+          "name": "Steel Meridian Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "Steel Meridian",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Arbiters of Hexis",
+      "rewards": [
+        {
+          "id": "arbiters_secura_dual_cestra",
+          "name": "Secura Dual Cestra",
+          "category": "syndicate_rewards",
+          "syndicate": "Arbiters of Hexis",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "arbiters_truth",
+          "name": "Truth",
+          "category": "syndicate_rewards",
+          "syndicate": "Arbiters of Hexis",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "arbiters_arbiters_of_hexis_sigil",
+          "name": "Arbiters of Hexis Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "Arbiters of Hexis",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        },
+        {
+          "id": "arbiters_arbiters_of_hexis_specter",
+          "name": "Arbiters of Hexis Specter Blueprint",
+          "category": "syndicate_rewards",
+          "syndicate": "Arbiters of Hexis",
+          "standingCost": 5000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Cephalon Suda",
+      "rewards": [
+        {
+          "id": "suda_synoid_gammacor",
+          "name": "Synoid Gammacor",
+          "category": "syndicate_rewards",
+          "syndicate": "Cephalon Suda",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "suda_entropy_burst",
+          "name": "Entropy Burst",
+          "category": "syndicate_rewards",
+          "syndicate": "Cephalon Suda",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "suda_entropy",
+          "name": "Entropy",
+          "category": "syndicate_rewards",
+          "syndicate": "Cephalon Suda",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "suda_cephalon_suda_sigil",
+          "name": "Cephalon Suda Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "Cephalon Suda",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Perrin Sequence",
+      "rewards": [
+        {
+          "id": "perrin_secura_lecta",
+          "name": "Secura Lecta",
+          "category": "syndicate_rewards",
+          "syndicate": "Perrin Sequence",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "perrin_sequence",
+          "name": "Sequence",
+          "category": "syndicate_rewards",
+          "syndicate": "Perrin Sequence",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "perrin_perrin_sequence_sigil",
+          "name": "Perrin Sequence Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "Perrin Sequence",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        },
+        {
+          "id": "perrin_perrin_sequence_specter",
+          "name": "Perrin Sequence Specter Blueprint",
+          "category": "syndicate_rewards",
+          "syndicate": "Perrin Sequence",
+          "standingCost": 5000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Red Veil",
+      "rewards": [
+        {
+          "id": "red_veil_rakta_ballistica",
+          "name": "Rakta Ballistica",
+          "category": "syndicate_rewards",
+          "syndicate": "Red Veil",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "red_veil_blight",
+          "name": "Blight",
+          "category": "syndicate_rewards",
+          "syndicate": "Red Veil",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "red_veil_red_veil_sigil",
+          "name": "Red Veil Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "Red Veil",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        },
+        {
+          "id": "red_veil_red_veil_specter",
+          "name": "Red Veil Specter Blueprint",
+          "category": "syndicate_rewards",
+          "syndicate": "Red Veil",
+          "standingCost": 5000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "New Loka",
+      "rewards": [
+        {
+          "id": "new_loka_sancti_tigris",
+          "name": "Sancti Tigris",
+          "category": "syndicate_rewards",
+          "syndicate": "New Loka",
+          "standingCost": 125000,
+          "masteryRank": 7,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "new_loka_purity",
+          "name": "Purity",
+          "category": "syndicate_rewards",
+          "syndicate": "New Loka",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        },
+        {
+          "id": "new_loka_new_loka_sigil",
+          "name": "New Loka Sigil",
+          "category": "syndicate_rewards",
+          "syndicate": "New Loka",
+          "standingCost": 5000,
+          "itemType": "cosmetic",
+          "status": "loading"
+        },
+        {
+          "id": "new_loka_new_loka_specter",
+          "name": "New Loka Specter Blueprint",
+          "category": "syndicate_rewards",
+          "syndicate": "New Loka",
+          "standingCost": 5000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Ostron",
+      "rewards": [
+        {
+          "id": "ostron_amp_111",
+          "name": "Amp (1-1-1)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 1000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_222",
+          "name": "Amp (2-2-2)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 5000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_333",
+          "name": "Amp (3-3-3)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 10000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_444",
+          "name": "Amp (4-4-4)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 15000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_555",
+          "name": "Amp (5-5-5)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 20000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_666",
+          "name": "Amp (6-6-6)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 25000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "ostron_amp_777",
+          "name": "Amp (7-7-7)",
+          "category": "syndicate_rewards",
+          "syndicate": "Ostron",
+          "standingCost": 30000,
+          "itemType": "weapon",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Solaris United",
+      "rewards": [
+        {
+          "id": "solaris_kitgun_primary",
+          "name": "Kitgun Primary",
+          "category": "syndicate_rewards",
+          "syndicate": "Solaris United",
+          "standingCost": 5000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "solaris_kitgun_secondary",
+          "name": "Kitgun Secondary",
+          "category": "syndicate_rewards",
+          "syndicate": "Solaris United",
+          "standingCost": 5000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "solaris_moa_pet",
+          "name": "MOA Pet",
+          "category": "syndicate_rewards",
+          "syndicate": "Solaris United",
+          "standingCost": 10000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Entrati",
+      "rewards": [
+        {
+          "id": "entrati_nepheri",
+          "name": "Nepheri",
+          "category": "syndicate_rewards",
+          "syndicate": "Entrati",
+          "standingCost": 5000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "entrati_voidrig",
+          "name": "Voidrig Necramech",
+          "category": "syndicate_rewards",
+          "syndicate": "Entrati",
+          "standingCost": 50000,
+          "itemType": "other",
+          "status": "loading"
+        },
+        {
+          "id": "entrati_bonewidow",
+          "name": "Bonewidow Necramech",
+          "category": "syndicate_rewards",
+          "syndicate": "Entrati",
+          "standingCost": 50000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Necraloid",
+      "rewards": [
+        {
+          "id": "necraloid_voidrig",
+          "name": "Voidrig Necramech",
+          "category": "syndicate_rewards",
+          "syndicate": "Necraloid",
+          "standingCost": 50000,
+          "itemType": "other",
+          "status": "loading"
+        },
+        {
+          "id": "necraloid_bonewidow",
+          "name": "Bonewidow Necramech",
+          "category": "syndicate_rewards",
+          "syndicate": "Necraloid",
+          "standingCost": 50000,
+          "itemType": "other",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Holdfasts",
+      "rewards": [
+        {
+          "id": "holdfasts_laetum",
+          "name": "Laetum",
+          "category": "syndicate_rewards",
+          "syndicate": "Holdfasts",
+          "standingCost": 20000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "holdfasts_phenmor",
+          "name": "Phenmor",
+          "category": "syndicate_rewards",
+          "syndicate": "Holdfasts",
+          "standingCost": 20000,
+          "itemType": "weapon",
+          "status": "loading"
+        },
+        {
+          "id": "holdfasts_praxaris",
+          "name": "Praxaris",
+          "category": "syndicate_rewards",
+          "syndicate": "Holdfasts",
+          "standingCost": 20000,
+          "itemType": "weapon",
+          "status": "loading"
+        }
+      ]
+    },
+    {
+      "name": "Cavalero",
+      "rewards": [
+        {
+          "id": "cavalero_archon_shard",
+          "name": "Archon Shard",
+          "category": "syndicate_rewards",
+          "syndicate": "Cavalero",
+          "standingCost": 150000,
+          "itemType": "resource",
+          "status": "loading"
+        },
+        {
+          "id": "cavalero_archon_mod",
+          "name": "Archon Mod",
+          "category": "syndicate_rewards",
+          "syndicate": "Cavalero",
+          "standingCost": 25000,
+          "itemType": "mod",
+          "status": "loading"
+        }
+      ]
+    }
+  ]
+}

--- a/src/components/InventorySection.tsx
+++ b/src/components/InventorySection.tsx
@@ -31,6 +31,8 @@ const getCategoryDisplayName = (category: ItemCategory): string => {
       return 'Prime Parts';
     case 'relics':
       return 'Void Relics';
+    case 'syndicate_rewards':
+      return 'Syndicate Rewards';
     default:
       return category;
   }

--- a/src/components/SyndicateRewardsSection.tsx
+++ b/src/components/SyndicateRewardsSection.tsx
@@ -1,0 +1,388 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { RefreshCw, ChevronDown, ChevronRight, Filter, TrendingUp, Shield, Zap } from 'lucide-react';
+import { SyndicateReward } from '../types';
+import { 
+  getAllSyndicateRewards, 
+  fetchSyndicateRewardPrices, 
+  sortSyndicateRewards, 
+  filterSyndicateRewards,
+  getAvailableSyndicates 
+} from '../services/syndicateService';
+
+interface SyndicateRewardsSectionProps {
+  isRefreshing: boolean;
+  onRefreshStart: () => void;
+  onRefreshComplete: () => void;
+}
+
+const SyndicateRewardsSection: React.FC<SyndicateRewardsSectionProps> = ({
+  isRefreshing,
+  onRefreshStart,
+  onRefreshComplete
+}) => {
+  const [rewards, setRewards] = useState<SyndicateReward[]>([]);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [showFilters, setShowFilters] = useState(false);
+  const [sortBy, setSortBy] = useState<'platPerStanding' | 'price' | 'standingCost' | 'name' | 'syndicate'>('platPerStanding');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [filters, setFilters] = useState({
+    syndicate: '',
+    itemType: '',
+    minPrice: '',
+    maxPrice: '',
+    minPlatPerStanding: '',
+    maxStandingCost: ''
+  });
+
+  // Load initial data
+  useEffect(() => {
+    const loadData = async () => {
+      // Wait a bit for the data to be loaded from JSON
+      await new Promise(resolve => setTimeout(resolve, 100));
+      const initialRewards = getAllSyndicateRewards();
+      setRewards(initialRewards);
+    };
+    loadData();
+  }, []);
+
+  // Apply filters and sorting
+  const filteredAndSortedRewards = useMemo(() => {
+    let filtered = rewards;
+
+    // Apply filters
+    if (filters.syndicate) {
+      filtered = filterSyndicateRewards(filtered, { syndicate: filters.syndicate });
+    }
+    if (filters.itemType) {
+      filtered = filterSyndicateRewards(filtered, { itemType: filters.itemType });
+    }
+    if (filters.minPrice) {
+      filtered = filterSyndicateRewards(filtered, { minPrice: parseFloat(filters.minPrice) });
+    }
+    if (filters.maxPrice) {
+      filtered = filterSyndicateRewards(filtered, { maxPrice: parseFloat(filters.maxPrice) });
+    }
+    if (filters.minPlatPerStanding) {
+      filtered = filterSyndicateRewards(filtered, { minPlatPerStanding: parseFloat(filters.minPlatPerStanding) });
+    }
+    if (filters.maxStandingCost) {
+      filtered = filterSyndicateRewards(filtered, { maxStandingCost: parseInt(filters.maxStandingCost) });
+    }
+
+    // Apply sorting
+    return sortSyndicateRewards(filtered, sortBy, sortOrder);
+  }, [rewards, filters, sortBy, sortOrder]);
+
+  // Calculate totals
+  const totals = useMemo(() => {
+    const loadedRewards = filteredAndSortedRewards.filter(r => r.status === 'loaded');
+    const totalValue = loadedRewards.reduce((sum, r) => sum + (r.price || 0), 0);
+    const totalStanding = loadedRewards.reduce((sum, r) => sum + r.standingCost, 0);
+    const avgPlatPerStanding = totalStanding > 0 ? totalValue / totalStanding : 0;
+    
+    return {
+      totalValue,
+      totalStanding,
+      avgPlatPerStanding,
+      loadedCount: loadedRewards.length,
+      totalCount: filteredAndSortedRewards.length
+    };
+  }, [filteredAndSortedRewards]);
+
+  const handleRefresh = async () => {
+    onRefreshStart();
+    try {
+      const updatedRewards = await fetchSyndicateRewardPrices(rewards);
+      setRewards(updatedRewards);
+    } catch (error) {
+      console.error('Failed to refresh syndicate rewards:', error);
+    } finally {
+      onRefreshComplete();
+    }
+  };
+
+  const handleSort = (newSortBy: typeof sortBy) => {
+    if (sortBy === newSortBy) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(newSortBy);
+      setSortOrder('desc');
+    }
+  };
+
+  const getSortIcon = (column: typeof sortBy) => {
+    if (sortBy !== column) return null;
+    return sortOrder === 'desc' ? '↓' : '↑';
+  };
+
+  const formatPlatPerStanding = (value: number | undefined) => {
+    if (!value) return 'N/A';
+    return `${value.toFixed(4)}`;
+  };
+
+  const formatStanding = (value: number) => {
+    return value.toLocaleString();
+  };
+
+  const getItemTypeColor = (itemType: string) => {
+    switch (itemType) {
+      case 'weapon': return 'text-red-400';
+      case 'mod': return 'text-blue-400';
+      case 'cosmetic': return 'text-purple-400';
+      case 'resource': return 'text-green-400';
+      default: return 'text-gray-400';
+    }
+  };
+
+  const syndicates = getAvailableSyndicates();
+
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-sm rounded-xl border border-gray-700/50 mb-4">
+      {/* Header */}
+      <div className="p-4 border-b border-gray-700/50">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="flex items-center gap-3 text-left group flex-1"
+          >
+            <div className="flex items-center gap-2">
+              {isExpanded ? (
+                <ChevronDown size={16} className="text-gray-400 group-hover:text-orokin-gold transition-colors" />
+              ) : (
+                <ChevronRight size={16} className="text-gray-400 group-hover:text-orokin-gold transition-colors" />
+              )}
+              <Shield size={20} className="text-orokin-gold" />
+              <span className="font-semibold text-lg">Syndicate Rewards</span>
+            </div>
+          </button>
+          
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowFilters(!showFilters)}
+              className={`p-2 rounded-lg transition-colors ${
+                showFilters ? 'bg-orokin-gold/20 text-orokin-gold' : 'bg-gray-700/50 text-gray-400 hover:text-white'
+              }`}
+            >
+              <Filter size={16} />
+            </button>
+            
+            <button
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="p-2 rounded-lg bg-gray-700/50 text-gray-400 hover:text-white disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            >
+              <RefreshCw size={16} className={isRefreshing ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        </div>
+
+        {/* Summary Stats */}
+        <div className="mt-3 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div className="bg-gray-800/50 rounded-lg p-3">
+            <div className="text-gray-400">Total Value</div>
+            <div className="text-orokin-gold font-semibold">{totals.totalValue.toLocaleString()}p</div>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-3">
+            <div className="text-gray-400">Avg Plat/Standing</div>
+            <div className="text-green-400 font-semibold">{formatPlatPerStanding(totals.avgPlatPerStanding)}</div>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-3">
+            <div className="text-gray-400">Items Loaded</div>
+            <div className="text-blue-400 font-semibold">{totals.loadedCount}/{totals.totalCount}</div>
+          </div>
+          <div className="bg-gray-800/50 rounded-lg p-3">
+            <div className="text-gray-400">Total Standing</div>
+            <div className="text-purple-400 font-semibold">{formatStanding(totals.totalStanding)}</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Filters */}
+      {showFilters && (
+        <div className="p-4 border-b border-gray-700/50 bg-gray-800/30">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Syndicate</label>
+              <select
+                value={filters.syndicate}
+                onChange={(e) => setFilters(prev => ({ ...prev, syndicate: e.target.value }))}
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              >
+                <option value="">All Syndicates</option>
+                {syndicates.map(syndicate => (
+                  <option key={syndicate} value={syndicate}>{syndicate}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Item Type</label>
+              <select
+                value={filters.itemType}
+                onChange={(e) => setFilters(prev => ({ ...prev, itemType: e.target.value }))}
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              >
+                <option value="">All Types</option>
+                <option value="weapon">Weapons</option>
+                <option value="mod">Mods</option>
+                <option value="cosmetic">Cosmetics</option>
+                <option value="resource">Resources</option>
+                <option value="other">Other</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Min Price (plat)</label>
+              <input
+                type="number"
+                value={filters.minPrice}
+                onChange={(e) => setFilters(prev => ({ ...prev, minPrice: e.target.value }))}
+                placeholder="0"
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Max Price (plat)</label>
+              <input
+                type="number"
+                value={filters.maxPrice}
+                onChange={(e) => setFilters(prev => ({ ...prev, maxPrice: e.target.value }))}
+                placeholder="∞"
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Min Plat/Standing</label>
+              <input
+                type="number"
+                step="0.0001"
+                value={filters.minPlatPerStanding}
+                onChange={(e) => setFilters(prev => ({ ...prev, minPlatPerStanding: e.target.value }))}
+                placeholder="0.0000"
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Max Standing Cost</label>
+              <input
+                type="number"
+                value={filters.maxStandingCost}
+                onChange={(e) => setFilters(prev => ({ ...prev, maxStandingCost: e.target.value }))}
+                placeholder="∞"
+                className="w-full bg-gray-700/50 border border-gray-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-orokin-gold"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {isExpanded && (
+        <div className="p-4">
+          {filteredAndSortedRewards.length === 0 ? (
+            <div className="text-center text-gray-400 py-8">
+              No syndicate rewards found matching the current filters.
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-gray-700/50">
+                    <th className="text-left p-2">
+                      <button
+                        onClick={() => handleSort('name')}
+                        className="flex items-center gap-1 hover:text-orokin-gold transition-colors"
+                      >
+                        Item Name {getSortIcon('name')}
+                      </button>
+                    </th>
+                    <th className="text-left p-2">
+                      <button
+                        onClick={() => handleSort('syndicate')}
+                        className="flex items-center gap-1 hover:text-orokin-gold transition-colors"
+                      >
+                        Syndicate {getSortIcon('syndicate')}
+                      </button>
+                    </th>
+                    <th className="text-left p-2">
+                      <button
+                        onClick={() => handleSort('standingCost')}
+                        className="flex items-center gap-1 hover:text-orokin-gold transition-colors"
+                      >
+                        Standing Cost {getSortIcon('standingCost')}
+                      </button>
+                    </th>
+                    <th className="text-left p-2">
+                      <button
+                        onClick={() => handleSort('price')}
+                        className="flex items-center gap-1 hover:text-orokin-gold transition-colors"
+                      >
+                        Market Price {getSortIcon('price')}
+                      </button>
+                    </th>
+                    <th className="text-left p-2">
+                      <button
+                        onClick={() => handleSort('platPerStanding')}
+                        className="flex items-center gap-1 hover:text-orokin-gold transition-colors"
+                      >
+                        <TrendingUp size={14} />
+                        Plat/Standing {getSortIcon('platPerStanding')}
+                      </button>
+                    </th>
+                    <th className="text-left p-2">Type</th>
+                    <th className="text-left p-2">Volume</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredAndSortedRewards.map((reward) => (
+                    <tr key={reward.id} className="border-b border-gray-700/30 hover:bg-gray-800/30 transition-colors">
+                      <td className="p-2">
+                        <div className="font-medium">{reward.name}</div>
+                        {reward.masteryRank && (
+                          <div className="text-xs text-gray-400">MR {reward.masteryRank}</div>
+                        )}
+                      </td>
+                      <td className="p-2 text-gray-300">{reward.syndicate}</td>
+                      <td className="p-2 text-purple-400">{formatStanding(reward.standingCost)}</td>
+                      <td className="p-2">
+                        {reward.status === 'loaded' ? (
+                          <div className="text-orokin-gold font-semibold">{reward.price?.toLocaleString()}p</div>
+                        ) : reward.status === 'error' ? (
+                          <div className="text-red-400 text-sm">{reward.error}</div>
+                        ) : (
+                          <div className="text-gray-400 text-sm">Loading...</div>
+                        )}
+                      </td>
+                      <td className="p-2">
+                        {reward.platPerStanding ? (
+                          <div className="text-green-400 font-semibold">
+                            {formatPlatPerStanding(reward.platPerStanding)}
+                          </div>
+                        ) : (
+                          <div className="text-gray-400 text-sm">N/A</div>
+                        )}
+                      </td>
+                      <td className="p-2">
+                        <span className={`text-xs px-2 py-1 rounded-full bg-gray-700/50 ${getItemTypeColor(reward.itemType)}`}>
+                          {reward.itemType}
+                        </span>
+                      </td>
+                      <td className="p-2 text-gray-400">
+                        {reward.marketVolume ? reward.marketVolume.toLocaleString() : 'N/A'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SyndicateRewardsSection;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import ImageUploader from '../components/ImageUploader';
 import ProcessingAnimation from '../components/ProcessingAnimation';
 import InventorySection from '../components/InventorySection';
+import SyndicateRewardsSection from '../components/SyndicateRewardsSection';
 import { analyzeImage, isGeminiConfigured } from '../services/geminiService';
 import { fetchPriceData, fetchSinglePriceData, fetchSinglePriceOnly } from '../services/warframeMarketService';
 import { cloudSyncService } from '../services/cloudSyncService';
@@ -44,7 +45,9 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
   const [lastPriceRefresh, setLastPriceRefresh] = useState<Date | null>(null);
   const [lastPrimePartsRefresh, setLastPrimePartsRefresh] = useState<Date | null>(null);
   const [lastRelicsRefresh, setLastRelicsRefresh] = useState<Date | null>(null);
+  const [lastSyndicateRewardsRefresh, setLastSyndicateRewardsRefresh] = useState<Date | null>(null);
   const [isRefreshingPrices, setIsRefreshingPrices] = useState(false);
+  const [isRefreshingSyndicateRewards, setIsRefreshingSyndicateRewards] = useState(false);
   const [refreshingCategories, setRefreshingCategories] = useState<Set<string>>(new Set());
   const [fetchingProgress, setFetchingProgress] = useState<{ current: number; total: number } | undefined>(undefined);
   const [categoryProgress, setCategoryProgress] = useState<{ category: string; current: number; total: number } | undefined>(undefined);
@@ -53,7 +56,8 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
   // Story #3 & #8: Categorized Persistent Inventory State
   const [categorizedInventory, setCategorizedInventory] = useState({
     prime_parts: [] as InventoryItem[],
-    relics: [] as InventoryItem[]
+    relics: [] as InventoryItem[],
+    syndicate_rewards: [] as InventoryItem[]
   });
 
   // Only sellable Prime Parts (uncrafted Blueprints)
@@ -1038,7 +1042,7 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
           )}
 
           {/* Upload section - show at top when we have results but not processing */}
-          {isConfigured && !isProcessing && (categorizedInventory.prime_parts.length > 0 || categorizedInventory.relics.length > 0) && (
+          {isConfigured && !isProcessing && (categorizedInventory.prime_parts.length > 0 || categorizedInventory.relics.length > 0 || categorizedInventory.syndicate_rewards.length > 0) && (
             <div className="bg-gray-800/40 backdrop-blur-sm rounded-xl border border-gray-700/50 p-4">
               <div className="flex items-center justify-between mb-3">
                 <h3 className="text-lg font-semibold">Add More Screenshots</h3>
@@ -1072,7 +1076,7 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
           )}
 
           {/* Story #8: Categorized Inventory Sections */}
-          {(categorizedInventory.prime_parts.length > 0 || categorizedInventory.relics.length > 0) && (
+          {(categorizedInventory.prime_parts.length > 0 || categorizedInventory.relics.length > 0 || categorizedInventory.syndicate_rewards.length > 0) && (
             <div className="space-y-2">
 
               {/* Prime Parts Section */}
@@ -1118,6 +1122,13 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
               )}
             </div>
           )}
+
+          {/* Syndicate Rewards Section - Always show for market analysis */}
+          <SyndicateRewardsSection
+            isRefreshing={isRefreshingSyndicateRewards}
+            onRefreshStart={() => setIsRefreshingSyndicateRewards(true)}
+            onRefreshComplete={() => setIsRefreshingSyndicateRewards(false)}
+          />
 
           {/* Empty state - only show when no processing and no results */}
           {!isProcessing && categorizedInventory.prime_parts.length === 0 && categorizedInventory.relics.length === 0 && processingState.images.size === 0 && (

--- a/src/services/inventoryService.ts
+++ b/src/services/inventoryService.ts
@@ -56,6 +56,7 @@ export interface InventoryItem {
 export interface CategorizedInventory {
   prime_parts: InventoryItem[];
   relics: InventoryItem[];
+  syndicate_rewards: InventoryItem[];
 }
 
 export interface InventoryStorage {
@@ -193,7 +194,8 @@ export const getCategorizedInventory = (): CategorizedInventory => {
 
   return {
     prime_parts: inventory.items.filter(item => item.category === 'prime_parts'),
-    relics: inventory.items.filter(item => item.category === 'relics')
+    relics: inventory.items.filter(item => item.category === 'relics'),
+    syndicate_rewards: inventory.items.filter(item => item.category === 'syndicate_rewards')
   };
 };
 

--- a/src/services/syndicateService.ts
+++ b/src/services/syndicateService.ts
@@ -1,0 +1,170 @@
+import { SyndicateReward } from '../types';
+import { fetchSinglePriceData } from './warframeMarketService';
+
+// Syndicate data structure
+export interface SyndicateData {
+  name: string;
+  rewards: SyndicateReward[];
+}
+
+// Load syndicate rewards data from JSON file
+let SYNDICATE_REWARDS_DATA: SyndicateData[] = [];
+
+/**
+ * Load syndicate rewards data from JSON file
+ */
+const loadSyndicateData = async (): Promise<SyndicateData[]> => {
+  try {
+    const response = await fetch('/syndicate-rewards.json');
+    if (!response.ok) {
+      throw new Error(`Failed to load syndicate data: ${response.statusText}`);
+    }
+    const data = await response.json();
+    
+    // Transform the data to include required fields
+    return data.syndicates.map((syndicate: any) => ({
+      name: syndicate.name,
+      rewards: syndicate.rewards.map((reward: any) => ({
+        ...reward,
+        addedAt: new Date(),
+        lastUpdated: new Date()
+      }))
+    }));
+  } catch (error) {
+    console.error('Failed to load syndicate data:', error);
+    return [];
+  }
+};
+
+// Initialize data on module load
+loadSyndicateData().then(data => {
+  SYNDICATE_REWARDS_DATA = data;
+}).catch(error => {
+  console.error('Failed to initialize syndicate data:', error);
+});
+
+/**
+ * Get all syndicate rewards
+ */
+export const getAllSyndicateRewards = (): SyndicateReward[] => {
+  return SYNDICATE_REWARDS_DATA.flatMap(syndicate => syndicate.rewards);
+};
+
+/**
+ * Get syndicate rewards by syndicate name
+ */
+export const getSyndicateRewards = (syndicateName: string): SyndicateReward[] => {
+  const syndicate = SYNDICATE_REWARDS_DATA.find(s => s.name === syndicateName);
+  return syndicate ? syndicate.rewards : [];
+};
+
+/**
+ * Get all available syndicates
+ */
+export const getAvailableSyndicates = (): string[] => {
+  return SYNDICATE_REWARDS_DATA.map(s => s.name);
+};
+
+/**
+ * Fetch market prices for syndicate rewards
+ */
+export const fetchSyndicateRewardPrices = async (rewards: SyndicateReward[]): Promise<SyndicateReward[]> => {
+  const updatedRewards: SyndicateReward[] = [];
+  
+  for (const reward of rewards) {
+    try {
+      const priceData = await fetchSinglePriceData(reward.name);
+      
+      if (priceData && priceData.price) {
+        const platPerStanding = priceData.price / reward.standingCost;
+        
+        updatedRewards.push({
+          ...reward,
+          price: priceData.price,
+          volume: priceData.volume,
+          average: priceData.average,
+          platPerStanding,
+          marketVolume: priceData.volume,
+          status: 'loaded',
+          lastUpdated: new Date()
+        });
+      } else {
+        updatedRewards.push({
+          ...reward,
+          status: 'error',
+          error: 'No price data available',
+          lastUpdated: new Date()
+        });
+      }
+    } catch (error) {
+      updatedRewards.push({
+        ...reward,
+        status: 'error',
+        error: error instanceof Error ? error.message : 'Failed to fetch price',
+        lastUpdated: new Date()
+      });
+    }
+  }
+  
+  return updatedRewards;
+};
+
+/**
+ * Sort syndicate rewards by various criteria
+ */
+export const sortSyndicateRewards = (
+  rewards: SyndicateReward[],
+  sortBy: 'platPerStanding' | 'price' | 'standingCost' | 'name' | 'syndicate',
+  sortOrder: 'asc' | 'desc' = 'desc'
+): SyndicateReward[] => {
+  return [...rewards].sort((a, b) => {
+    let comparison = 0;
+    
+    switch (sortBy) {
+      case 'platPerStanding':
+        const aRatio = a.platPerStanding || 0;
+        const bRatio = b.platPerStanding || 0;
+        comparison = aRatio - bRatio;
+        break;
+      case 'price':
+        comparison = (a.price || 0) - (b.price || 0);
+        break;
+      case 'standingCost':
+        comparison = a.standingCost - b.standingCost;
+        break;
+      case 'name':
+        comparison = a.name.localeCompare(b.name);
+        break;
+      case 'syndicate':
+        comparison = a.syndicate.localeCompare(b.syndicate);
+        break;
+    }
+    
+    return sortOrder === 'desc' ? -comparison : comparison;
+  });
+};
+
+/**
+ * Filter syndicate rewards
+ */
+export const filterSyndicateRewards = (
+  rewards: SyndicateReward[],
+  filters: {
+    syndicate?: string;
+    itemType?: string;
+    minPrice?: number;
+    maxPrice?: number;
+    minPlatPerStanding?: number;
+    maxStandingCost?: number;
+  }
+): SyndicateReward[] => {
+  return rewards.filter(reward => {
+    if (filters.syndicate && reward.syndicate !== filters.syndicate) return false;
+    if (filters.itemType && reward.itemType !== filters.itemType) return false;
+    if (filters.minPrice && (reward.price || 0) < filters.minPrice) return false;
+    if (filters.maxPrice && (reward.price || 0) > filters.maxPrice) return false;
+    if (filters.minPlatPerStanding && (reward.platPerStanding || 0) < filters.minPlatPerStanding) return false;
+    if (filters.maxStandingCost && reward.standingCost > filters.maxStandingCost) return false;
+    return true;
+  });
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 import { FileWithPath } from 'react-dropzone';
 
-export type ItemCategory = 'prime_parts' | 'relics';
+export type ItemCategory = 'prime_parts' | 'relics' | 'syndicate_rewards';
 
 export interface BaseItem {
   id: string;
@@ -47,7 +47,18 @@ export interface VoidRelic extends BaseItem {
   };
 }
 
-export type DetectedItem = PrimePart | VoidRelic;
+export interface SyndicateReward extends BaseItem {
+  category: 'syndicate_rewards';
+  syndicate: string;
+  standingCost: number;
+  masteryRank?: number;
+  itemType: 'weapon' | 'mod' | 'cosmetic' | 'resource' | 'other';
+  platPerStanding?: number;
+  marketVolume?: number;
+  availability?: 'always' | 'rotation' | 'limited';
+}
+
+export type DetectedItem = PrimePart | VoidRelic | SyndicateReward;
 
 export interface ImageState {
   id: string;

--- a/test-syndicate.html
+++ b/test-syndicate.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Syndicate Rewards Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #1a1a1a;
+            color: #ffffff;
+        }
+        .test-section {
+            background-color: #2a2a2a;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+        }
+        .reward-item {
+            background-color: #3a3a3a;
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+            border-left: 4px solid #ffd700;
+        }
+        .stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 10px;
+            margin: 20px 0;
+        }
+        .stat-card {
+            background-color: #4a4a4a;
+            padding: 15px;
+            border-radius: 4px;
+            text-align: center;
+        }
+        .stat-value {
+            font-size: 24px;
+            font-weight: bold;
+            color: #ffd700;
+        }
+        .stat-label {
+            font-size: 12px;
+            color: #cccccc;
+        }
+        button {
+            background-color: #ffd700;
+            color: #000;
+            border: none;
+            padding: 10px 20px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+        }
+        button:hover {
+            background-color: #ffed4e;
+        }
+        .loading {
+            color: #ffd700;
+        }
+        .error {
+            color: #ff6b6b;
+        }
+        .success {
+            color: #51cf66;
+        }
+    </style>
+</head>
+<body>
+    <h1>Syndicate Rewards Test</h1>
+    
+    <div class="test-section">
+        <h2>Data Loading Test</h2>
+        <button onclick="testDataLoading()">Load Syndicate Data</button>
+        <div id="loading-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Price Fetching Test</h2>
+        <button onclick="testPriceFetching()">Fetch Prices</button>
+        <div id="price-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Sorting Test</h2>
+        <button onclick="testSorting()">Sort by Plat/Standing</button>
+        <div id="sort-result"></div>
+    </div>
+
+    <div class="test-section">
+        <h2>Filtering Test</h2>
+        <button onclick="testFiltering()">Filter Weapons Only</button>
+        <div id="filter-result"></div>
+    </div>
+
+    <script type="module">
+        // Import the syndicate service functions
+        import { 
+            getAllSyndicateRewards, 
+            fetchSyndicateRewardPrices, 
+            sortSyndicateRewards, 
+            filterSyndicateRewards,
+            getAvailableSyndicates 
+        } from './src/services/syndicateService.js';
+
+        // Make functions available globally for testing
+        window.testDataLoading = async function() {
+            const resultDiv = document.getElementById('loading-result');
+            resultDiv.innerHTML = '<div class="loading">Loading syndicate data...</div>';
+            
+            try {
+                // Wait a bit for data to load
+                await new Promise(resolve => setTimeout(resolve, 500));
+                
+                const rewards = getAllSyndicateRewards();
+                const syndicates = getAvailableSyndicates();
+                
+                resultDiv.innerHTML = `
+                    <div class="success">
+                        ✅ Successfully loaded ${rewards.length} rewards from ${syndicates.length} syndicates
+                    </div>
+                    <div class="stats">
+                        <div class="stat-card">
+                            <div class="stat-value">${rewards.length}</div>
+                            <div class="stat-label">Total Rewards</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-value">${syndicates.length}</div>
+                            <div class="stat-label">Syndicates</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-value">${rewards.filter(r => r.itemType === 'weapon').length}</div>
+                            <div class="stat-label">Weapons</div>
+                        </div>
+                        <div class="stat-card">
+                            <div class="stat-value">${rewards.filter(r => r.itemType === 'mod').length}</div>
+                            <div class="stat-label">Mods</div>
+                        </div>
+                    </div>
+                    <h3>Sample Rewards:</h3>
+                    ${rewards.slice(0, 5).map(reward => `
+                        <div class="reward-item">
+                            <strong>${reward.name}</strong> (${reward.syndicate})<br>
+                            Standing Cost: ${reward.standingCost.toLocaleString()}<br>
+                            Type: ${reward.itemType}
+                        </div>
+                    `).join('')}
+                `;
+            } catch (error) {
+                resultDiv.innerHTML = `<div class="error">❌ Error: ${error.message}</div>`;
+            }
+        };
+
+        window.testPriceFetching = async function() {
+            const resultDiv = document.getElementById('price-result');
+            resultDiv.innerHTML = '<div class="loading">Fetching prices...</div>';
+            
+            try {
+                const rewards = getAllSyndicateRewards();
+                const sampleRewards = rewards.slice(0, 3); // Test with first 3 items
+                
+                const updatedRewards = await fetchSyndicateRewardPrices(sampleRewards);
+                
+                resultDiv.innerHTML = `
+                    <div class="success">✅ Successfully fetched prices for ${updatedRewards.length} items</div>
+                    ${updatedRewards.map(reward => `
+                        <div class="reward-item">
+                            <strong>${reward.name}</strong><br>
+                            Price: ${reward.price ? reward.price + 'p' : 'N/A'}<br>
+                            Plat/Standing: ${reward.platPerStanding ? reward.platPerStanding.toFixed(4) : 'N/A'}<br>
+                            Status: ${reward.status}
+                        </div>
+                    `).join('')}
+                `;
+            } catch (error) {
+                resultDiv.innerHTML = `<div class="error">❌ Error: ${error.message}</div>`;
+            }
+        };
+
+        window.testSorting = async function() {
+            const resultDiv = document.getElementById('sort-result');
+            resultDiv.innerHTML = '<div class="loading">Sorting rewards...</div>';
+            
+            try {
+                const rewards = getAllSyndicateRewards();
+                const sortedRewards = sortSyndicateRewards(rewards, 'platPerStanding', 'desc');
+                
+                resultDiv.innerHTML = `
+                    <div class="success">✅ Sorted ${sortedRewards.length} rewards by plat/standing ratio</div>
+                    <h3>Top 5 by Plat/Standing Ratio:</h3>
+                    ${sortedRewards.slice(0, 5).map((reward, index) => `
+                        <div class="reward-item">
+                            <strong>#${index + 1}: ${reward.name}</strong> (${reward.syndicate})<br>
+                            Standing Cost: ${reward.standingCost.toLocaleString()}<br>
+                            Plat/Standing: ${reward.platPerStanding ? reward.platPerStanding.toFixed(4) : 'N/A'}
+                        </div>
+                    `).join('')}
+                `;
+            } catch (error) {
+                resultDiv.innerHTML = `<div class="error">❌ Error: ${error.message}</div>`;
+            }
+        };
+
+        window.testFiltering = async function() {
+            const resultDiv = document.getElementById('filter-result');
+            resultDiv.innerHTML = '<div class="loading">Filtering weapons...</div>';
+            
+            try {
+                const rewards = getAllSyndicateRewards();
+                const weaponRewards = filterSyndicateRewards(rewards, { itemType: 'weapon' });
+                
+                resultDiv.innerHTML = `
+                    <div class="success">✅ Found ${weaponRewards.length} weapon rewards</div>
+                    <h3>Weapon Rewards:</h3>
+                    ${weaponRewards.map(reward => `
+                        <div class="reward-item">
+                            <strong>${reward.name}</strong> (${reward.syndicate})<br>
+                            Standing Cost: ${reward.standingCost.toLocaleString()}<br>
+                            Mastery Rank: ${reward.masteryRank || 'N/A'}
+                        </div>
+                    `).join('')}
+                `;
+            } catch (error) {
+                resultDiv.innerHTML = `<div class="error">❌ Error: ${error.message}</div>`;
+            }
+        };
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Add a new section for Warframe Syndicate Rewards market analysis, allowing users to sort by plat/standing ratio to optimize standing spending.

---
<a href="https://cursor.com/background-agent?bcId=bc-fff55e66-445b-49b2-9855-0c61d8934694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fff55e66-445b-49b2-9855-0c61d8934694">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

