### PR TITLE
Fix prime set completion logic for market sales

### DIFF
--- a/src/components/PrimeSetsSection.tsx
+++ b/src/components/PrimeSetsSection.tsx
@@ -55,6 +55,7 @@ import {
   updateAllReservations,
   isItemReserved
 } from '../services/buildPlanService';
+import { toggleItemOwned, isItemOwned } from '../services/ownedItemsService';
 
 interface PrimeSetsProps {
   primePartsInventory: DetectedItem[];
@@ -296,6 +297,21 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
       case 'Sentinel': return <Hexagon size={16} />;
       default: return <Package size={16} />;
     }
+  };
+
+  // Handle toggling owned status for individual parts
+  const handlePartOwnedToggle = (partName: string) => {
+    toggleItemOwned(partName);
+    // Refresh the data to update completion percentages
+    setRefreshKey(prev => prev + 1);
+  };
+
+  // Calculate real completion percentage based on owned status
+  const getRealCompletionPercentage = (progress: SetProgress): number => {
+    const ownedCount = progress.set.requiredParts.filter(part => 
+      progress.ownedParts.includes(part.name) && isItemOwned(part.name)
+    ).length;
+    return (ownedCount / progress.set.requiredParts.length) * 100;
   };
 
   const getProgressColor = (percentage: number) => {
@@ -1099,23 +1115,28 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                 <div className="mb-2">
                   <div className="flex items-center justify-between text-xs text-gray-400 mb-1">
                     <span>Progress</span>
-                    <span>{Math.round(progress.completionPercentage)}%</span>
+                    <span>{Math.round(getRealCompletionPercentage(progress))}%</span>
                   </div>
                   <div className="w-full bg-gray-800 rounded-full h-2 relative overflow-hidden">
                     {/* Owned parts (green) */}
                     <div
                       className="h-2 bg-green-500 rounded-full transition-all absolute left-0 top-0"
-                      style={{ width: `${(progress.ownedParts.length / progress.set.requiredParts.length) * 100}%` }}
+                      style={{ width: `${getRealCompletionPercentage(progress)}%` }}
                     />
                     {/* Parts obtainable from relics (recommended color) */}
                     {(() => {
                       const overlayColorClass = getOverlayColorForSet(progress);
+                      const realOwnedCount = progress.set.requiredParts.filter(part => 
+                        progress.ownedParts.includes(part.name) && isItemOwned(part.name)
+                      ).length;
+                      const obtainableWidth = (progress.obtainableFromRelics.filter(part => !progress.ownedParts.includes(part)).length / progress.set.requiredParts.length) * 100;
+                      const inventoryWidth = (progress.ownedParts.filter(part => !isItemOwned(part)).length / progress.set.requiredParts.length) * 100;
                       return (
                         <div
                           className={`h-2 ${overlayColorClass} rounded-full transition-all absolute top-0`}
                           style={{
-                            left: `${(progress.ownedParts.length / progress.set.requiredParts.length) * 100}%`,
-                            width: `${(progress.obtainableFromRelics.filter(part => !progress.ownedParts.includes(part)).length / progress.set.requiredParts.length) * 100}%`
+                            left: `${getRealCompletionPercentage(progress)}%`,
+                            width: `${obtainableWidth + inventoryWidth}%`
                           }}
                         />
                       );
@@ -1148,6 +1169,26 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                 <div className="px-3 pb-3 border-t border-gray-700/50">
                   <div className="space-y-3 pt-3">
 
+                      {/* Legend */}
+                      <div className="flex items-center gap-4 text-xs text-gray-400 mb-2">
+                        <div className="flex items-center gap-1">
+                          <CheckCircle size={12} className="text-green-400" />
+                          <span>Owned (keep)</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Package size={12} className="text-blue-400" />
+                          <span>In Inventory (can sell)</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Hexagon size={12} className="text-yellow-400" />
+                          <span>From Relics</span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Circle size={12} className="text-gray-500" />
+                          <span>Missing</span>
+                        </div>
+                      </div>
+
                       {/* Parts List */}
                       <div className="space-y-1">
                         <div className="flex items-center justify-between text-xs mb-1">
@@ -1174,15 +1215,22 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                           .map((part, index) => {
                           const isOwned = progress.ownedParts.includes(part.name);
                           const isObtainableFromRelics = progress.obtainableFromRelics.includes(part.name);
+                          const isMarkedAsOwned = isItemOwned(part.name);
 
                           let iconColor = 'text-gray-500';
                           let textColor = 'text-gray-500';
                           let icon = <Circle size={12} />;
 
                           if (isOwned) {
-                            iconColor = 'text-green-400';
-                            textColor = 'text-green-400';
-                            icon = <CheckCircle size={12} />;
+                            if (isMarkedAsOwned) {
+                              iconColor = 'text-green-400';
+                              textColor = 'text-green-400';
+                              icon = <CheckCircle size={12} />;
+                            } else {
+                              iconColor = 'text-blue-400';
+                              textColor = 'text-blue-400';
+                              icon = <Package size={12} />;
+                            }
                           } else if (isObtainableFromRelics) {
                             iconColor = 'text-yellow-400';
                             textColor = 'text-yellow-400';
@@ -1203,10 +1251,22 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                                 {part.itemCount && part.itemCount > 1 && (
                                   <span className="text-xs text-blue-400">x{part.itemCount}</span>
                                 )}
+                                {/* Owned status toggle button */}
+                                <button
+                                  onClick={() => handlePartOwnedToggle(part.name)}
+                                  className={`ml-2 p-1 rounded transition-colors ${
+                                    isMarkedAsOwned 
+                                      ? 'text-green-400 hover:text-green-300' 
+                                      : 'text-gray-500 hover:text-gray-300'
+                                  }`}
+                                  title={isMarkedAsOwned ? "Mark as not owned (can sell)" : "Mark as owned (keep for yourself)"}
+                                >
+                                  {isMarkedAsOwned ? <CheckCircle size={12} /> : <Circle size={12} />}
+                                </button>
                               </div>
                               <div className="flex flex-col items-end gap-1 text-right">
                                 <span className={`${textColor} text-xs`}>
-                                  {isOwned ? 'Owned' : (
+                                  {isOwned ? (isMarkedAsOwned ? 'Owned' : 'In Inventory') : (
                                     isObtainableFromRelics ? (
                                       <span className="text-gray-400"></span>
                                     ) : (

--- a/src/services/ownedItemsService.ts
+++ b/src/services/ownedItemsService.ts
@@ -1,0 +1,75 @@
+// Purpose: Manage owned items state - distinguish between inventory items and truly owned items
+// Author: Assistant
+// Last Updated: 2025-01-28
+
+import { DetectedItem } from '../types';
+
+const OWNED_ITEMS_KEY = 'warframe_owned_items';
+
+// Get all owned items from localStorage
+export const getOwnedItems = (): Set<string> => {
+  try {
+    const stored = localStorage.getItem(OWNED_ITEMS_KEY);
+    if (stored) {
+      const ownedItems = JSON.parse(stored);
+      return new Set(ownedItems);
+    }
+  } catch (error) {
+    console.error('Failed to load owned items from localStorage:', error);
+  }
+  return new Set();
+};
+
+// Save owned items to localStorage
+export const saveOwnedItems = (ownedItems: Set<string>): void => {
+  try {
+    localStorage.setItem(OWNED_ITEMS_KEY, JSON.stringify(Array.from(ownedItems)));
+  } catch (error) {
+    console.error('Failed to save owned items to localStorage:', error);
+  }
+};
+
+// Check if an item is marked as owned
+export const isItemOwned = (itemName: string): boolean => {
+  const ownedItems = getOwnedItems();
+  return ownedItems.has(itemName.toLowerCase());
+};
+
+// Mark an item as owned
+export const markItemAsOwned = (itemName: string): void => {
+  const ownedItems = getOwnedItems();
+  ownedItems.add(itemName.toLowerCase());
+  saveOwnedItems(ownedItems);
+};
+
+// Mark an item as not owned (can be sold)
+export const markItemAsNotOwned = (itemName: string): void => {
+  const ownedItems = getOwnedItems();
+  ownedItems.delete(itemName.toLowerCase());
+  saveOwnedItems(ownedItems);
+};
+
+// Toggle the owned status of an item
+export const toggleItemOwned = (itemName: string): boolean => {
+  const isOwned = isItemOwned(itemName);
+  if (isOwned) {
+    markItemAsNotOwned(itemName);
+    return false;
+  } else {
+    markItemAsOwned(itemName);
+    return true;
+  }
+};
+
+// Get owned items from inventory (items that are both in inventory and marked as owned)
+export const getOwnedItemsFromInventory = (inventory: DetectedItem[]): DetectedItem[] => {
+  return inventory.filter(item => isItemOwned(item.name));
+};
+
+// Update inventory items with their owned status
+export const updateInventoryWithOwnedStatus = (inventory: DetectedItem[]): DetectedItem[] => {
+  return inventory.map(item => ({
+    ...item,
+    isOwned: isItemOwned(item.name)
+  }));
+};

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -4,6 +4,7 @@
 
 import { DetectedItem, VoidRelic } from '../types';
 import { cloudSyncService } from './cloudSyncService';
+import { isItemOwned } from './ownedItemsService';
 
 export interface PrimePart {
   name: string;
@@ -301,7 +302,7 @@ export const toggleSetMastery = (setId: string): void => {
   setMasteredSets(updated);
 };
 
-// Check if user owns a specific part
+// Check if user owns a specific part (only counts items marked as owned)
 const ownsItem = (itemName: string, requiredCount: number, inventory: DetectedItem[]): boolean => {
   const lowerItemName = itemName.toLowerCase();
   const inventoryItem = inventory.find(item => {
@@ -309,10 +310,13 @@ const ownsItem = (itemName: string, requiredCount: number, inventory: DetectedIt
     return (lowerInventoryItemName === lowerItemName || lowerInventoryItemName === `${lowerItemName} blueprint`);
   });
 
-  const result = inventoryItem ? (inventoryItem.quantity || 1) >= requiredCount : false;
+  // Check if item exists in inventory AND is marked as owned
+  if (!inventoryItem || (inventoryItem.quantity || 1) < requiredCount) {
+    return false;
+  }
 
-
-  return result;
+  // Only count toward completion if the item is marked as owned
+  return isItemOwned(inventoryItem.name);
 };
 
 // Check if user can obtain a part from owned relics

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,6 +17,8 @@ export interface BaseItem {
   // Buyer information for whisper message generation
   buyerUsername?: string | null;
   buyerQuantity?: number;
+  // NEW: Distinguish between inventory items and truly owned items
+  isOwned?: boolean; // true = user wants to keep this item, false/undefined = can be sold
 }
 
 export interface PrimePart extends BaseItem {

--- a/test-owned-items.html
+++ b/test-owned-items.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Owned Items Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background-color: #1a1a1a;
+            color: #ffffff;
+        }
+        .test-section {
+            background-color: #2a2a2a;
+            padding: 20px;
+            margin: 20px 0;
+            border-radius: 8px;
+        }
+        .test-result {
+            padding: 10px;
+            margin: 10px 0;
+            border-radius: 4px;
+        }
+        .success {
+            background-color: #1a4a1a;
+            border: 1px solid #4a8a4a;
+        }
+        .error {
+            background-color: #4a1a1a;
+            border: 1px solid #8a4a4a;
+        }
+        button {
+            background-color: #4a4a4a;
+            color: white;
+            border: none;
+            padding: 8px 16px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin: 5px;
+        }
+        button:hover {
+            background-color: #6a6a6a;
+        }
+        .item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 5px;
+            border: 1px solid #3a3a3a;
+            margin: 5px 0;
+            border-radius: 4px;
+        }
+        .owned {
+            background-color: #1a4a1a;
+        }
+        .inventory {
+            background-color: #1a1a4a;
+        }
+    </style>
+</head>
+<body>
+    <h1>Owned Items Service Test</h1>
+    
+    <div class="test-section">
+        <h2>Test Owned Items Functionality</h2>
+        <p>This test verifies that the owned items service correctly distinguishes between inventory items and truly owned items.</p>
+        
+        <div class="test-result success">
+            <h3>Test Case: Acceltra Prime Set</h3>
+            <p><strong>Scenario:</strong> User has all 4 parts of Acceltra Prime in inventory but only wants to keep 1 part for themselves.</p>
+            
+            <div class="item inventory">
+                <span>🔵 Acceltra Prime Barrel (In Inventory - can sell)</span>
+                <button onclick="toggleOwned('Acceltra Prime Barrel')">Mark as Owned</button>
+            </div>
+            <div class="item inventory">
+                <span>🔵 Acceltra Prime Blueprint (In Inventory - can sell)</span>
+                <button onclick="toggleOwned('Acceltra Prime Blueprint')">Mark as Owned</button>
+            </div>
+            <div class="item inventory">
+                <span>🔵 Acceltra Prime Receiver (In Inventory - can sell)</span>
+                <button onclick="toggleOwned('Acceltra Prime Receiver')">Mark as Owned</button>
+            </div>
+            <div class="item inventory">
+                <span>🔵 Acceltra Prime Stock (In Inventory - can sell)</span>
+                <button onclick="toggleOwned('Acceltra Prime Stock')">Mark as Owned</button>
+            </div>
+            
+            <div id="completion-status">
+                <p><strong>Completion Status:</strong> <span id="completion-percentage">0%</span> (0/4 parts truly owned)</p>
+                <p><strong>Can sell complete set:</strong> <span id="can-sell">Yes</span></p>
+            </div>
+        </div>
+        
+        <div class="test-result">
+            <h3>Instructions:</h3>
+            <ol>
+                <li>Click "Mark as Owned" on parts you want to keep for yourself</li>
+                <li>Watch the completion percentage update</li>
+                <li>Notice that you can still sell the complete set if you don't mark all parts as owned</li>
+            </ol>
+        </div>
+    </div>
+
+    <script>
+        // Simple implementation of the owned items service for testing
+        const OWNED_ITEMS_KEY = 'test_owned_items';
+        
+        function getOwnedItems() {
+            try {
+                const stored = localStorage.getItem(OWNED_ITEMS_KEY);
+                if (stored) {
+                    return new Set(JSON.parse(stored));
+                }
+            } catch (error) {
+                console.error('Failed to load owned items:', error);
+            }
+            return new Set();
+        }
+        
+        function saveOwnedItems(ownedItems) {
+            try {
+                localStorage.setItem(OWNED_ITEMS_KEY, JSON.stringify(Array.from(ownedItems)));
+            } catch (error) {
+                console.error('Failed to save owned items:', error);
+            }
+        }
+        
+        function isItemOwned(itemName) {
+            const ownedItems = getOwnedItems();
+            return ownedItems.has(itemName.toLowerCase());
+        }
+        
+        function toggleItemOwned(itemName) {
+            const ownedItems = getOwnedItems();
+            const isOwned = isItemOwned(itemName);
+            
+            if (isOwned) {
+                ownedItems.delete(itemName.toLowerCase());
+            } else {
+                ownedItems.add(itemName.toLowerCase());
+            }
+            
+            saveOwnedItems(ownedItems);
+            updateDisplay();
+        }
+        
+        function updateDisplay() {
+            const parts = [
+                'Acceltra Prime Barrel',
+                'Acceltra Prime Blueprint', 
+                'Acceltra Prime Receiver',
+                'Acceltra Prime Stock'
+            ];
+            
+            const ownedCount = parts.filter(part => isItemOwned(part)).length;
+            const completionPercentage = (ownedCount / parts.length) * 100;
+            const canSell = ownedCount < parts.length;
+            
+            document.getElementById('completion-percentage').textContent = `${completionPercentage}%`;
+            document.getElementById('can-sell').textContent = canSell ? 'Yes' : 'No';
+            
+            // Update item displays
+            parts.forEach(part => {
+                const itemElement = document.querySelector(`[onclick="toggleOwned('${part}')"]`).parentElement;
+                const isOwned = isItemOwned(part);
+                
+                if (isOwned) {
+                    itemElement.className = 'item owned';
+                    itemElement.querySelector('span').textContent = `🟢 ${part} (Owned - keeping)`;
+                    itemElement.querySelector('button').textContent = 'Mark as Not Owned';
+                } else {
+                    itemElement.className = 'item inventory';
+                    itemElement.querySelector('span').textContent = `🔵 ${part} (In Inventory - can sell)`;
+                    itemElement.querySelector('button').textContent = 'Mark as Owned';
+                }
+            });
+        }
+        
+        function toggleOwned(itemName) {
+            toggleItemOwned(itemName);
+        }
+        
+        // Initialize display
+        updateDisplay();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Introduce explicit "owned" status for prime parts to differentiate between inventory items for sale and items kept for personal collection, ensuring accurate set completion tracking.

Previously, having all parts of a prime set in inventory would mark the set as 100% complete, even if the user intended to sell the complete set. This change allows users to explicitly mark which parts they intend to keep, providing a true completion percentage for their personal collection while still allowing them to hold and sell full sets from their inventory.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dd23ec1-39f6-433d-85b8-d71237184ff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dd23ec1-39f6-433d-85b8-d71237184ff3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

