### PR TITLE
Set selling logic improvement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,6 +164,166 @@ const relics = getRelicsCache();         // relicDataService
 - **`RelicAnalysisCard`**: Expected value analysis and recommendations
 - **`ApiKeySettings`**: Secure API key management
 
+## 📦 Inventory Sections Architecture
+
+The application has **5 inventory sections**, each with different architectural patterns. This section documents the differences and why they exist.
+
+### Architecture Patterns
+
+#### Pattern 1: Wrapper Pattern (`InventorySection`)
+
+**Used by:**
+- Prime Parts (`PrimeParts.tsx`)
+- Void Relics (`RelicResultsTable.tsx`)
+
+**Structure:**
+```tsx
+<InventorySection
+  category="prime_parts" | "relics"
+  onRefreshAll={(itemsToRefresh?: InventoryItem[]) => void}
+  onRefreshItem={(itemName: string) => void}
+  onRemoveItem={(itemName: string) => void}
+  ...
+/>
+```
+
+**Characteristics:**
+- ✅ Consistent header/accordion UI via wrapper
+- ✅ Unified refresh button and progress tracking
+- ✅ Filtered refresh support via `visibleItems` state
+- ✅ Same prop interface for both sections
+- ✅ Refresh handlers in `HomePage.tsx`
+
+**Refresh Flow:**
+1. Component calls `onFilteredItemsChange(filteredItems)` → `InventorySection` stores in `visibleItems`
+2. User clicks refresh → `InventorySection` calls `onRefreshAll(visibleItems || undefined)`
+3. `HomePage` handler receives filtered items and refreshes only those
+
+---
+
+#### Pattern 2: Standalone Pattern
+
+**Used by:**
+- Syndicate Rewards (`SyndicateRewardsSection.tsx`)
+- Mod Duplicates (`ModDuplicatesSection.tsx`)
+- Prime Sets (`PrimeSetsSection.tsx`)
+
+**Structure:**
+Each component is fully self-contained with its own:
+- Header/accordion UI
+- Filtering logic
+- Refresh handlers
+- Progress tracking
+
+**Differences:**
+
+| Component | Refresh Prop | Filtered Refresh | Cancel Support | Complete Callback |
+|-----------|-------------|------------------|----------------|-------------------|
+| **SyndicateRewards** | `onRefreshStart(itemsToRefresh?)` | ✅ Yes | ✅ Yes | ✅ Yes |
+| **ModDuplicates** | `onRefreshStart(itemsToRefresh?)` | ✅ Yes | ✅ Yes | ✅ Yes |
+| **PrimeSets** | Internal `handleRefreshPrimeSets()` | ✅ Yes | ❌ No | ❌ No |
+
+**Why Different?**
+
+1. **SyndicateRewards & ModDuplicates:**
+   - More complex refresh logic (progress tracking, cancellation)
+   - Custom filtering needs (syndicate types, mod rarity, etc.)
+   - Need `onRefreshComplete` callback for state management
+   - Similar patterns (ModDuplicates follows SyndicateRewards pattern)
+
+2. **PrimeSets:**
+   - Completely different data model (`SetProgress[]` vs `InventoryItem[]`)
+   - Self-contained refresh logic (no external handler needed)
+   - Complex filtering (vaulted, warframes, weapons, completion status)
+   - Investment analysis calculations
+   - No need for external refresh callbacks
+
+---
+
+### Filtered Refresh Implementation
+
+**All sections support filtered refresh**, but implementation differs:
+
+#### Wrapper Pattern (Prime Parts, Relics)
+```typescript
+// InventorySection.tsx
+const [visibleItems, setVisibleItems] = useState<InventoryItem[] | null>(null);
+
+// Component reports filtered items
+onFilteredItemsChange(filteredItems);
+
+// Refresh passes filtered items
+onRefreshAll(visibleItems || undefined);
+```
+
+#### Standalone Pattern (Syndicate, Mods, Prime Sets)
+```typescript
+// Each component checks filters internally
+const handleRefresh = async () => {
+  const itemsToRefresh = activeFilters.has('all')
+    ? allItems
+    : filteredItems;
+  
+  onRefreshStart(itemsToRefresh); // Syndicate/Mods
+  // OR
+  handleRefreshPrimeSets(); // Prime Sets (internal)
+};
+```
+
+---
+
+### Component Comparison
+
+| Feature | Prime Parts | Relics | Syndicate | Mods | Prime Sets |
+|---------|-------------|--------|-----------|------|------------|
+| **Wrapper Component** | ✅ `InventorySection` | ✅ `InventorySection` | ❌ Standalone | ❌ Standalone | ❌ Standalone |
+| **Refresh Prop** | `onRefreshAll` | `onRefreshAll` | `onRefreshStart` | `onRefreshStart` | Internal |
+| **Filtered Refresh** | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes | ✅ Yes |
+| **Progress Tracking** | Via wrapper | Via wrapper | Via props | Via props | Internal |
+| **Cancel Support** | ❌ No | ❌ No | ✅ Yes | ✅ Yes | ❌ No |
+| **Refresh Complete** | ❌ No | ❌ No | ✅ Yes | ✅ Yes | ❌ No |
+| **Data Type** | `InventoryItem[]` | `InventoryItem[]` | `SyndicateReward[]` | `ModItem[]` | `SetProgress[]` |
+
+---
+
+### Why Not Standardize?
+
+**Current State:**
+- ✅ All sections work correctly
+- ✅ All support filtered refresh
+- ✅ Each optimized for its specific needs
+
+**Risks of Standardization:**
+- 🔴 Breaking changes to working code
+- 🔴 Different data types don't map easily
+- 🔴 Prime Sets would require major refactoring
+- 🔴 Testing burden (5 sections × multiple features)
+- 🔴 No user benefit, only developer convenience
+
+**Recommendation:**
+- ✅ **Keep as-is** - Document differences (this section)
+- ✅ **Standardize incrementally** - Only when adding new features
+- ✅ **Don't force uniformity** - Different needs justify different patterns
+
+---
+
+### Future Considerations
+
+**When to Standardize:**
+- Adding a new feature that needs consistency across all sections
+- Refactoring a specific section for other reasons
+- Differences cause actual maintenance problems
+
+**Safe Standardization Steps:**
+1. **Low Risk**: Standardize prop names (`onRefreshStart` → `onRefreshAll`)
+2. **Medium Risk**: Add missing features (cancel support, complete callbacks)
+3. **High Risk**: Full architectural refactor (not recommended)
+
+**Current Priority:**
+- ✅ Document differences (done)
+- ✅ Ensure filtered refresh works (done)
+- ⏸️ Standardization (deferred - not needed)
+
 ### Data Storage
 - **LocalStorage**: API keys and user preferences
 - **SessionStorage**: Temporary processing state

--- a/src/components/PrimeSetsSection.tsx
+++ b/src/components/PrimeSetsSection.tsx
@@ -83,7 +83,7 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
   const [lastRefreshTime, setLastRefreshTime] = useState<Date | null>(null);
   const [copiedItems, setCopiedItems] = useState<Set<string>>(new Set());
   const [expandedSets, setExpandedSets] = useState<Set<string>>(new Set());
-  const [refreshingSet, setRefreshingSet] = useState<string | null>(null);
+  const [refreshingSets, setRefreshingSets] = useState<Set<string>>(new Set());
   const [copiedSetId, setCopiedSetId] = useState<string | null>(null);
   const [sortField, setSortField] = useState<'priority' | 'roi' | 'setValue' | 'partsValue' | 'completion' | 'investment'>('priority');
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
@@ -159,20 +159,31 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
     setIsRefreshing(true);
 
     // Get currently visible sets based on filters
+    // If filters are active (not "all"), only refresh filtered sets
+    // Otherwise refresh all sets
     const visibleSets = filteredSets();
     const visibleSetNames = visibleSets.map(p => p.set.name);
+    
+    // If no filters active (showing all), refresh all sets
+    // Otherwise only refresh filtered sets (QoL feature)
+    const setsToRefresh = activeFilters.has('all') 
+      ? setProgress.map(p => p.set.name) 
+      : visibleSetNames;
 
-    setRefreshProgress({ current: 0, total: visibleSetNames.length });
+    setRefreshProgress({ current: 0, total: setsToRefresh.length });
 
     try {
+      // Mark all sets as refreshing
+      setRefreshingSets(new Set(setsToRefresh));
+      
       // Process sets one by one to provide progressive progress updates
       const updatedProgresses: SetProgress[] = [];
       
-      for (let i = 0; i < visibleSetNames.length; i++) {
-        const setName = visibleSetNames[i];
+      for (let i = 0; i < setsToRefresh.length; i++) {
+        const setName = setsToRefresh[i];
         
         // Update progress
-        setRefreshProgress({ current: i, total: visibleSetNames.length });
+        setRefreshProgress({ current: i, total: setsToRefresh.length });
         
         try {
           // Refresh individual set market data
@@ -197,7 +208,10 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
       }
       
       // Final progress update
-      setRefreshProgress({ current: visibleSetNames.length, total: visibleSetNames.length });
+      setRefreshProgress({ current: setsToRefresh.length, total: setsToRefresh.length });
+      
+      // Clear refreshing state
+      setRefreshingSets(new Set());
       
       // Trigger a refresh to ensure all updates are reflected
       setRefreshKey((prev: number) => prev + 1);
@@ -215,8 +229,18 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
   };
 
   const handleRefreshIndividualSet = async (setNameOrProgress: string | SetProgress) => {
+    const setName = typeof setNameOrProgress === 'string' ? setNameOrProgress : setNameOrProgress.set.name;
+    
+    // Prevent duplicate refresh requests
+    if (refreshingSets.has(setName)) {
+      console.log(`⏭️ [Refresh] ${setName} already refreshing, skipping duplicate request`);
+      return;
+    }
+    
     try {
-      const setName = typeof setNameOrProgress === 'string' ? setNameOrProgress : setNameOrProgress.set.name;
+      // Mark as refreshing
+      setRefreshingSets(prev => new Set(prev).add(setName));
+      
       const updatedProgress = await refreshIndividualSetMarketData(setName, primePartsInventory, relicsInventory);
 
       if (updatedProgress) {
@@ -227,6 +251,13 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
       }
     } catch (error) {
       console.error('Failed to refresh individual set:', error);
+    } finally {
+      // Clear refreshing state
+      setRefreshingSets(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(setName);
+        return newSet;
+      });
     }
   };
 
@@ -1532,7 +1563,7 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                         : 'bg-gray-800/30 border-gray-600/30 text-gray-400';
                     })()
                   }`}>
-                    💰 {progress.recommendedStrategy === 'SELL_PARTS' ? 'SELL PARTS' : progress.recommendedStrategy === 'BUY_MISSING' ? 'BUY MISSING PARTS TO COMPLETE SET' : progress.recommendedStrategy.replace(/_/g, ' ')}
+                    💰 {progress.recommendedStrategy === 'SELL_PARTS' ? 'SELL PARTS' : progress.recommendedStrategy === 'SELL_SET' ? 'SELL SET' : progress.recommendedStrategy === 'BUY_MISSING' ? 'BUY MISSING PARTS TO COMPLETE SET' : progress.recommendedStrategy.replace(/_/g, ' ')}
                     {(() => {
                       // Show ROI if available from investment analysis
                       const profit = progress.investmentAnalysis?.expectedProfit ?? 0;
@@ -1610,24 +1641,19 @@ const PrimeSetsSection: React.FC<PrimeSetsProps> = ({
                   <div className="flex items-center gap-2">
                     {/* Refresh Button */}
                     <button
-                      onClick={async (e) => {
+                      onClick={(e) => {
                         e.stopPropagation();
-                        setRefreshingSet(progress.set.name);
-                        try {
-                          await handleRefreshIndividualSet(progress.set.name);
-                        } finally {
-                          setRefreshingSet(null);
-                        }
+                        handleRefreshIndividualSet(progress);
                       }}
-                      disabled={refreshingSet === progress.set.name}
+                      disabled={refreshingSets.has(progress.set.name)}
                       className={`p-1 rounded text-xs transition-colors ${
-                        refreshingSet === progress.set.name
+                        refreshingSets.has(progress.set.name)
                           ? 'text-gray-500 cursor-not-allowed'
                           : 'text-tenno-blue hover:bg-gray-700/50'
                       }`}
                       title="Refresh market prices"
                     >
-                      <RefreshCw size={12} className={refreshingSet === progress.set.name ? 'animate-spin' : ''} />
+                      <RefreshCw size={12} className={refreshingSets.has(progress.set.name) ? 'animate-spin' : ''} />
                     </button>
                   </div>
 

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1551,7 +1551,7 @@ const HomePage: React.FC<HomePageProps> = ({ isConfigured, onOpenSettings, refre
                 isRefreshing={refreshingCategories.has('relics')}
                 progress={categoryProgress?.category === 'relics' ? categoryProgress : undefined}
                 lastRefreshTime={lastRelicsRefresh}
-                onRefreshAll={() => handleRefreshCategoryPrices('relics')}
+                onRefreshAll={(itemsToRefresh) => handleRefreshCategoryPrices('relics', itemsToRefresh)}
                 onClearAll={() => handleClearInventory('relics')}
                 onRefreshItem={handleRefreshSingleItem}
                 onRemoveItem={handleRemoveFromInventory}

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -45,7 +45,7 @@ export interface SetProgress {
   completeSetBuyerQuantity?: number;
   individualPartsValue?: number;
   profitDifference?: number;
-  recommendedStrategy?: 'SELL_PARTS' | 'BUILD_AND_SELL' | 'KEEP_FOR_MASTERY' | 'OPEN_RELICS' | 'BUY_MISSING' | 'HYBRID_STRATEGY' | 'INSUFFICIENT_DATA';
+  recommendedStrategy?: 'SELL_PARTS' | 'SELL_SET' | 'KEEP_FOR_MASTERY' | 'OPEN_RELICS' | 'BUY_MISSING' | 'HYBRID_STRATEGY' | 'INSUFFICIENT_DATA';
   setMarketStatus?: 'loaded' | 'loading' | 'error';
   setMarketError?: string;
   // NEW: Investment Analysis
@@ -882,12 +882,12 @@ const determineOptimalStrategyWithInvestment = (
     // Set can be sold - compare real sellable value
     if (individualPartsValue === 0 && completeSetPrice > 0) {
       // No parts can be sold individually, but set can be sold - definitely sell the set
-      console.log(`🎯 [Strategy] ${setProgress.set.name}: No parts sellable individually, but set can be sold → BUILD_AND_SELL`);
-      return 'BUILD_AND_SELL';
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: No parts sellable individually, but set can be sold → SELL_SET`);
+      return 'SELL_SET';
     } else if (individualPartsValue < completeSetPrice) {
       // Set is worth more than sellable parts - sell the set
-      console.log(`🎯 [Strategy] ${setProgress.set.name}: Set price (${completeSetPrice}p) > parts value (${individualPartsValue}p) → BUILD_AND_SELL`);
-      return 'BUILD_AND_SELL';
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: Set price (${completeSetPrice}p) > parts value (${individualPartsValue}p) → SELL_SET`);
+      return 'SELL_SET';
     } else if (partsWithoutBuyers > 0 && completeSetPrice > 0) {
       // Some parts can't be sold individually, but set can be sold
       // If set price is reasonable (at least 50% of parts value), sell the set
@@ -898,8 +898,8 @@ const determineOptimalStrategyWithInvestment = (
       console.log(`🎯 [Strategy] ${setProgress.set.name}: Some parts unsellable (${partsWithoutBuyers}/${partsWithBuyers + partsWithoutBuyers}), valueRatio=${partsValueRatio.toFixed(2)}, unsellableRatio=${unsellableRatio.toFixed(2)}`);
       
       if (partsValueRatio >= 0.5 || unsellableRatio > 0.5) {
-        console.log(`🎯 [Strategy] ${setProgress.set.name}: Unsellable parts detected, set price reasonable → BUILD_AND_SELL`);
-        return 'BUILD_AND_SELL';
+        console.log(`🎯 [Strategy] ${setProgress.set.name}: Unsellable parts detected, set price reasonable → SELL_SET`);
+        return 'SELL_SET';
       }
     }
   }

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -629,6 +629,7 @@ export const isPrimePartTradeable = (itemName: string): boolean => {
 // NEW: Calculate the total market value of owned individual parts
 // Excludes built warframe parts (non-blueprint chassis/systems/neuroptics) as they cannot be traded
 // If both built part and blueprint exist, prefer blueprint (tradeable)
+// CRITICAL: Only counts parts with buyers (hasBuyers === true) - parts without buyers cannot be sold
 const calculateIndividualPartsValue = (
   ownedParts: string[],
   primePartsInventory: DetectedItem[],
@@ -673,7 +674,12 @@ const calculateIndividualPartsValue = (
       return; // Built warframe component cannot be traded
     }
 
-    if (inventoryItem && inventoryItem.price && inventoryItem.price > 0) {
+    // CRITICAL: Only count parts that have buyers AND a price > 0
+    // Parts without buyers cannot be sold, so they have no value
+    if (inventoryItem && 
+        inventoryItem.price && 
+        inventoryItem.price > 0 && 
+        inventoryItem.hasBuyers === true) {
       const quantity = inventoryItem.quantity || 1;
       totalValue += inventoryItem.price * quantity;
     }
@@ -796,6 +802,10 @@ const calculateInvestmentAnalysis = (
 // If we can't get a real price from the market or inventory, use 0
 
 // NEW: Enhanced strategy determination with investment analysis
+// Smart formula that considers:
+// 1. Parts with buyers vs no buyers (unsellable parts)
+// 2. Set with buyers vs no buyers
+// 3. Real sellable value comparison
 const determineOptimalStrategyWithInvestment = (
   setProgress: SetProgress,
   individualPartsValue: number,
@@ -812,6 +822,85 @@ const determineOptimalStrategyWithInvestment = (
     // Only recommend buying if there are missing parts to buy
     if (investmentAnalysis.missingPartsToBuy.length > 0 || investmentAnalysis.missingPartsFromRelics.length > 0) {
       return 'BUY_MISSING';
+    }
+  }
+
+  // SMART FORMULA: Check if set has buyers
+  const setHasBuyers = setProgress.completeSetBuyerUsername != null || 
+                       (setProgress.completeSetBuyerQuantity != null && setProgress.completeSetBuyerQuantity > 0) ||
+                       completeSetPrice > 0; // If price > 0, assume buyers exist (from market data)
+
+  // Count how many owned parts have buyers vs no buyers
+  const primePartsInventory = getCategorizedInventory().prime_parts || [];
+  let partsWithBuyers = 0;
+  let partsWithoutBuyers = 0;
+  
+  setProgress.ownedParts.forEach(partName => {
+    let inventoryItem: DetectedItem | undefined;
+    
+    if (setProgress.set.type === 'Warframe') {
+      const blueprintItem = primePartsInventory.find(item => {
+        const lowerItemName = item.name.toLowerCase();
+        const lowerPartName = partName.toLowerCase();
+        return lowerItemName === `${lowerPartName} blueprint` || 
+               lowerItemName === `${lowerPartName.replace(/\s+/g, '_')}_blueprint`;
+      });
+      inventoryItem = blueprintItem || primePartsInventory.find(item => {
+        const lowerItemName = item.name.toLowerCase();
+        const lowerPartName = partName.toLowerCase();
+        return lowerItemName === lowerPartName || lowerItemName === lowerPartName.replace(/\s+/g, '_');
+      });
+    } else {
+      inventoryItem = primePartsInventory.find(item => {
+        const lowerItemName = item.name.toLowerCase();
+        const lowerPartName = partName.toLowerCase();
+        return lowerItemName === lowerPartName || lowerItemName === `${lowerPartName} blueprint`;
+      });
+    }
+
+    if (inventoryItem && 
+        !isBuiltWarframeInventoryItem(inventoryItem.name, setProgress.set.type)) {
+      if (inventoryItem.hasBuyers === true && inventoryItem.price && inventoryItem.price > 0) {
+        partsWithBuyers++;
+      } else {
+        partsWithoutBuyers++;
+      }
+    }
+  });
+
+  // SMART DECISION LOGIC:
+  // 1. If set has buyers and individualPartsValue < set price, sell the set
+  //    (This catches cases like Bronco Prime where some parts have no buyers)
+  // 2. If set has buyers and individualPartsValue >= set price, sell parts
+  // 3. If set has no buyers but parts have buyers, sell parts
+  // 4. If some parts have no buyers, heavily favor selling the set (if set has buyers)
+  // 5. If NO parts have buyers but set has buyers, definitely sell the set
+  
+  console.log(`🎯 [Strategy Logic] ${setProgress.set.name}: partsValue=${individualPartsValue}p, setPrice=${completeSetPrice}p, setHasBuyers=${setHasBuyers}, partsWithBuyers=${partsWithBuyers}, partsWithoutBuyers=${partsWithoutBuyers}`);
+  
+  if (setHasBuyers) {
+    // Set can be sold - compare real sellable value
+    if (individualPartsValue === 0 && completeSetPrice > 0) {
+      // No parts can be sold individually, but set can be sold - definitely sell the set
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: No parts sellable individually, but set can be sold → BUILD_AND_SELL`);
+      return 'BUILD_AND_SELL';
+    } else if (individualPartsValue < completeSetPrice) {
+      // Set is worth more than sellable parts - sell the set
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: Set price (${completeSetPrice}p) > parts value (${individualPartsValue}p) → BUILD_AND_SELL`);
+      return 'BUILD_AND_SELL';
+    } else if (partsWithoutBuyers > 0 && completeSetPrice > 0) {
+      // Some parts can't be sold individually, but set can be sold
+      // If set price is reasonable (at least 50% of parts value), sell the set
+      // OR if more than half the parts have no buyers, sell the set
+      const partsValueRatio = individualPartsValue > 0 ? completeSetPrice / individualPartsValue : 1;
+      const unsellableRatio = partsWithoutBuyers / (partsWithBuyers + partsWithoutBuyers);
+      
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: Some parts unsellable (${partsWithoutBuyers}/${partsWithBuyers + partsWithoutBuyers}), valueRatio=${partsValueRatio.toFixed(2)}, unsellableRatio=${unsellableRatio.toFixed(2)}`);
+      
+      if (partsValueRatio >= 0.5 || unsellableRatio > 0.5) {
+        console.log(`🎯 [Strategy] ${setProgress.set.name}: Unsellable parts detected, set price reasonable → BUILD_AND_SELL`);
+        return 'BUILD_AND_SELL';
+      }
     }
   }
 

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -699,21 +699,23 @@ const calculateIndividualPartsValue = (
       }
     } else {
       const hasPrice = inventoryItem.price && inventoryItem.price > 0;
-      const hasBuyers = inventoryItem.hasBuyers === true;
-      // FIXED: If price > 0, assume there are buyers (price comes from buyer orders)
-      // hasBuyers might be undefined in some cases, so we check price as primary indicator
-      const shouldCount = hasPrice && (hasBuyers !== false); // Count if price > 0 and hasBuyers is not explicitly false
+      const hasBuyers = inventoryItem.hasBuyers;
+      
+      // FIXED: If price > 0, there ARE buyers (price is the highest buy order from Warframe Market API)
+      // The hasBuyers field might be stale/incorrect, but price > 0 is definitive proof of buyers
+      // Only exclude if price is 0 or undefined (no buyers = no price)
+      const shouldCount = hasPrice; // Count if price > 0, regardless of hasBuyers value
       
       console.log(`💰 [Parts Value] Part "${partName}": found="${inventoryItem.name}", price=${inventoryItem.price || 0}, hasBuyers=${hasBuyers}, willCount=${shouldCount}`);
       
-      // CRITICAL: Count parts with price > 0 (buyer price implies buyers exist)
-      // Only exclude if hasBuyers is explicitly false
+      // CRITICAL: Count parts with price > 0 (buyer price = buyers exist)
+      // Price comes from buyer orders, so price > 0 means buyers exist
       if (shouldCount) {
         const quantity = inventoryItem.quantity || 1;
         totalValue += inventoryItem.price * quantity;
         console.log(`💰 [Parts Value] Added ${inventoryItem.price * quantity}p for "${partName}" (total: ${totalValue}p)`);
       } else {
-        console.warn(`💰 [Parts Value] Part "${partName}" excluded: price=${inventoryItem.price || 0}, hasBuyers=${hasBuyers}`);
+        console.warn(`💰 [Parts Value] Part "${partName}" excluded: price=${inventoryItem.price || 0}, hasBuyers=${hasBuyers} (no price = no buyers)`);
       }
     }
   });

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -662,10 +662,20 @@ const calculateIndividualPartsValue = (
       }
     } else {
       // For weapons, find any matching item
+      // Try multiple matching strategies for better compatibility
       inventoryItem = primePartsInventory.find(item => {
         const lowerItemName = item.name.toLowerCase();
         const lowerPartName = partName.toLowerCase();
-        return lowerItemName === lowerPartName || lowerItemName === `${lowerPartName} blueprint`;
+        // Try exact match
+        if (lowerItemName === lowerPartName) return true;
+        // Try with blueprint suffix
+        if (lowerItemName === `${lowerPartName} blueprint`) return true;
+        // Try underscore format
+        const underscorePartName = lowerPartName.replace(/\s+/g, '_');
+        if (lowerItemName === underscorePartName) return true;
+        // Try underscore with blueprint
+        if (lowerItemName === `${underscorePartName}_blueprint`) return true;
+        return false;
       });
     }
 
@@ -674,17 +684,41 @@ const calculateIndividualPartsValue = (
       return; // Built warframe component cannot be traded
     }
 
-    // CRITICAL: Only count parts that have buyers AND a price > 0
-    // Parts without buyers cannot be sold, so they have no value
-    if (inventoryItem && 
-        inventoryItem.price && 
-        inventoryItem.price > 0 && 
-        inventoryItem.hasBuyers === true) {
-      const quantity = inventoryItem.quantity || 1;
-      totalValue += inventoryItem.price * quantity;
+    // Debug logging for troubleshooting
+    if (!inventoryItem) {
+      console.warn(`💰 [Parts Value] Part "${partName}" not found in inventory (${primePartsInventory.length} items available)`);
+      // Try to find similar items for debugging
+      const similarItems = primePartsInventory.filter(item => {
+        const lowerItemName = item.name.toLowerCase();
+        const lowerPartName = partName.toLowerCase();
+        return lowerItemName.includes(lowerPartName.split(' ').pop() || '') || 
+               lowerPartName.includes(lowerItemName.split(' ').pop() || '');
+      });
+      if (similarItems.length > 0) {
+        console.warn(`💰 [Parts Value] Similar items found: ${similarItems.map(i => i.name).join(', ')}`);
+      }
+    } else {
+      const hasPrice = inventoryItem.price && inventoryItem.price > 0;
+      const hasBuyers = inventoryItem.hasBuyers === true;
+      // FIXED: If price > 0, assume there are buyers (price comes from buyer orders)
+      // hasBuyers might be undefined in some cases, so we check price as primary indicator
+      const shouldCount = hasPrice && (hasBuyers !== false); // Count if price > 0 and hasBuyers is not explicitly false
+      
+      console.log(`💰 [Parts Value] Part "${partName}": found="${inventoryItem.name}", price=${inventoryItem.price || 0}, hasBuyers=${hasBuyers}, willCount=${shouldCount}`);
+      
+      // CRITICAL: Count parts with price > 0 (buyer price implies buyers exist)
+      // Only exclude if hasBuyers is explicitly false
+      if (shouldCount) {
+        const quantity = inventoryItem.quantity || 1;
+        totalValue += inventoryItem.price * quantity;
+        console.log(`💰 [Parts Value] Added ${inventoryItem.price * quantity}p for "${partName}" (total: ${totalValue}p)`);
+      } else {
+        console.warn(`💰 [Parts Value] Part "${partName}" excluded: price=${inventoryItem.price || 0}, hasBuyers=${hasBuyers}`);
+      }
     }
   });
 
+  console.log(`💰 [Parts Value] Total value for ${ownedParts.length} parts: ${totalValue}p`);
   return totalValue;
 };
 

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -756,6 +756,10 @@ const calculateInvestmentAnalysis = (
     console.log(`💰 [Investment] Using fetched prices for ${missingPartsToBuy.length} parts to buy`);
     // Use fetched prices (more accurate) - these should be seller prices
     missingPartsToBuy.forEach(partName => {
+      // Find the PrimePart object to get itemCount (how many of this part are needed)
+      const primePart = setProgress.set.requiredParts.find(p => p.name === partName);
+      const itemCount = primePart?.itemCount || 1; // Default to 1 if not specified
+      
       const fetchedPrice = fetchedPrices.find(p => {
         const pName = p.name.toLowerCase();
         const partNameLower = partName.toLowerCase();
@@ -771,8 +775,9 @@ const calculateInvestmentAnalysis = (
       });
       if (fetchedPrice) {
         if (fetchedPrice.price > 0) {
-          buyInvestmentCost += fetchedPrice.price;
-          console.log(`💰 [Investment] ${partName}: ${fetchedPrice.price}p (from fetched price)`);
+          const totalCost = fetchedPrice.price * itemCount;
+          buyInvestmentCost += totalCost;
+          console.log(`💰 [Investment] ${partName}: ${fetchedPrice.price}p × ${itemCount} = ${totalCost}p (from fetched price)`);
         } else {
           console.warn(`💰 [Investment] ${partName}: No seller price in fetched data (using 0)`);
         }
@@ -1121,12 +1126,24 @@ export const analyzeSetProgressWithMarketData = async (
                 });
 
               // Calculate cost using SELLER prices ONLY for parts that must be BOUGHT (not from relics)
-              const missingCost = priced
-                .filter((p, i) => partsToBuy.includes(missingPartItems[i].name))
-                .reduce((sum, p) => {
-                  const cost = (p && p.sellerPrice && p.sellerPrice > 0) ? p.sellerPrice : 0;
-                  return sum + cost;
-                }, 0);
+              // FIXED: Account for itemCount (some parts need multiple copies, e.g., Ninkondi Prime Handle x2)
+              let missingCost = 0;
+              priced.forEach((p, i) => {
+                const originalPartName = (missingPartItems[i] as any).originalName || missingPartItems[i].name;
+                if (partsToBuy.includes(originalPartName)) {
+                  // Find the PrimePart object to get itemCount (how many of this part are needed)
+                  const primePart = progress.set.requiredParts.find(part => part.name === originalPartName);
+                  const itemCount = primePart?.itemCount || 1; // Default to 1 if not specified
+                  
+                  const cost = (p && p.sellerPrice && p.sellerPrice > 0) ? p.sellerPrice * itemCount : 0;
+                  if (cost > 0) {
+                    if (itemCount > 1) {
+                      console.log(`💰 [Batch] ${originalPartName}: ${p.sellerPrice}p × ${itemCount} = ${cost}p`);
+                    }
+                    missingCost += cost;
+                  }
+                }
+              });
               progress.missingCost = missingCost;
 
               // Store the prices temporarily - will be added to investmentAnalysis later
@@ -1430,12 +1447,21 @@ export const refreshIndividualSetMarketData = async (
 
             // Calculate cost using SELLER prices ONLY for parts that must be BOUGHT (not from relics)
             // Use the stored prices from missingPartsWithPrices (which uses original names) instead of priced array
+            // FIXED: Account for itemCount (some parts need multiple copies, e.g., Ninkondi Prime Handle x2)
             const missingCost = missingPartsWithPrices
               .filter(p => partsToBuy.includes(p.name))
               .reduce((sum, p) => {
-                const cost = p.price > 0 ? p.price : 0;
+                // Find the PrimePart object to get itemCount (how many of this part are needed)
+                const primePart = setProgress.set.requiredParts.find(part => part.name === p.name);
+                const itemCount = primePart?.itemCount || 1; // Default to 1 if not specified
+                
+                const cost = p.price > 0 ? p.price * itemCount : 0;
                 if (cost > 0) {
-                  console.log(`💰 [Cost Calc] ${p.name}: ${cost}p`);
+                  if (itemCount > 1) {
+                    console.log(`💰 [Cost Calc] ${p.name}: ${p.price}p × ${itemCount} = ${cost}p`);
+                  } else {
+                    console.log(`💰 [Cost Calc] ${p.name}: ${cost}p`);
+                  }
                 } else {
                   console.warn(`💰 [Cost Calc] ${p.name}: No seller price (using 0, not fallback estimate)`);
                 }

--- a/src/services/primeSetService.ts
+++ b/src/services/primeSetService.ts
@@ -858,11 +858,17 @@ const determineOptimalStrategyWithInvestment = (
     return 'INSUFFICIENT_DATA';
   }
 
-  // If we have investment analysis and it shows good ROI (buy missing parts to complete set)
-  if (investmentAnalysis && investmentAnalysis.expectedProfit > 5) {
-    // Only recommend buying if there are missing parts to buy
-    if (investmentAnalysis.missingPartsToBuy.length > 0 || investmentAnalysis.missingPartsFromRelics.length > 0) {
+  // PRIORITY: If there are missing parts, check if buying them is profitable
+  // Only recommend BUY_MISSING if buying missing parts is profitable (expectedProfit > 0)
+  // This takes priority over SELL_SET because completing the set is usually better than selling parts
+  if (investmentAnalysis && 
+      (investmentAnalysis.missingPartsToBuy.length > 0 || investmentAnalysis.missingPartsFromRelics.length > 0)) {
+    // If buying missing parts is profitable (even slightly), recommend BUY_MISSING
+    if (investmentAnalysis.expectedProfit > 0) {
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: Missing parts detected, expectedProfit=${investmentAnalysis.expectedProfit}p → BUY_MISSING`);
       return 'BUY_MISSING';
+    } else {
+      console.log(`🎯 [Strategy] ${setProgress.set.name}: Missing parts detected but not profitable (expectedProfit=${investmentAnalysis.expectedProfit}p), will check SELL_SET`);
     }
   }
 
@@ -910,25 +916,38 @@ const determineOptimalStrategyWithInvestment = (
   });
 
   // SMART DECISION LOGIC:
-  // 1. If set has buyers and individualPartsValue < set price, sell the set
+  // PRIORITY ORDER:
+  // 1. If there are missing parts AND buying them is profitable → BUY_MISSING (already checked above)
+  // 2. If set has buyers and individualPartsValue < set price, sell the set
   //    (This catches cases like Bronco Prime where some parts have no buyers)
-  // 2. If set has buyers and individualPartsValue >= set price, sell parts
-  // 3. If set has no buyers but parts have buyers, sell parts
-  // 4. If some parts have no buyers, heavily favor selling the set (if set has buyers)
-  // 5. If NO parts have buyers but set has buyers, definitely sell the set
+  // 3. If set has buyers and individualPartsValue >= set price, sell parts
+  // 4. If set has no buyers but parts have buyers, sell parts
+  // 5. If some parts have no buyers, heavily favor selling the set (if set has buyers)
+  // 6. If NO parts have buyers but set has buyers, definitely sell the set
   
-  console.log(`🎯 [Strategy Logic] ${setProgress.set.name}: partsValue=${individualPartsValue}p, setPrice=${completeSetPrice}p, setHasBuyers=${setHasBuyers}, partsWithBuyers=${partsWithBuyers}, partsWithoutBuyers=${partsWithoutBuyers}`);
+  console.log(`🎯 [Strategy Logic] ${setProgress.set.name}: partsValue=${individualPartsValue}p, setPrice=${completeSetPrice}p, setHasBuyers=${setHasBuyers}, partsWithBuyers=${partsWithBuyers}, partsWithoutBuyers=${partsWithoutBuyers}, hasMissingParts=${investmentAnalysis ? (investmentAnalysis.missingPartsToBuy.length > 0 || investmentAnalysis.missingPartsFromRelics.length > 0) : false}`);
   
   if (setHasBuyers) {
     // Set can be sold - compare real sellable value
+    // BUT: Only recommend SELL_SET if there are NO missing parts OR buying them is not profitable
+    const hasMissingParts = investmentAnalysis && 
+      (investmentAnalysis.missingPartsToBuy.length > 0 || investmentAnalysis.missingPartsFromRelics.length > 0);
+    const buyingNotProfitable = !investmentAnalysis || investmentAnalysis.expectedProfit <= 0;
+    
     if (individualPartsValue === 0 && completeSetPrice > 0) {
       // No parts can be sold individually, but set can be sold - definitely sell the set
-      console.log(`🎯 [Strategy] ${setProgress.set.name}: No parts sellable individually, but set can be sold → SELL_SET`);
-      return 'SELL_SET';
+      // UNLESS buying missing parts is profitable
+      if (!hasMissingParts || buyingNotProfitable) {
+        console.log(`🎯 [Strategy] ${setProgress.set.name}: No parts sellable individually, but set can be sold → SELL_SET`);
+        return 'SELL_SET';
+      }
     } else if (individualPartsValue < completeSetPrice) {
       // Set is worth more than sellable parts - sell the set
-      console.log(`🎯 [Strategy] ${setProgress.set.name}: Set price (${completeSetPrice}p) > parts value (${individualPartsValue}p) → SELL_SET`);
-      return 'SELL_SET';
+      // UNLESS buying missing parts is profitable (completing set is better than selling incomplete)
+      if (!hasMissingParts || buyingNotProfitable) {
+        console.log(`🎯 [Strategy] ${setProgress.set.name}: Set price (${completeSetPrice}p) > parts value (${individualPartsValue}p) → SELL_SET`);
+        return 'SELL_SET';
+      }
     } else if (partsWithoutBuyers > 0 && completeSetPrice > 0) {
       // Some parts can't be sold individually, but set can be sold
       // If set price is reasonable (at least 50% of parts value), sell the set

--- a/src/services/warframeMarketService.ts
+++ b/src/services/warframeMarketService.ts
@@ -261,17 +261,23 @@ const fetchViaDirect = async (normalizedName: string) => {
       order.visible
     );
 
+    const price = buyOrders.length > 0 ? Math.max(...buyOrders.map((o: any) => o.platinum)) : 0;
+    
     return {
       name: itemDetails.en.item_name,
       thumb: itemDetails.thumb,
       ducats: itemDetails.ducats || 0,
-      price: buyOrders.length > 0 ? Math.max(...buyOrders.map((o: any) => o.platinum)) : 0,
+      price: price,
       volume: ordersData.payload.orders.length,
       average: allValidOrders.length > 0
         ? Math.round(allValidOrders.reduce((acc: number, o: any) => acc + o.platinum, 0) / allValidOrders.length)
         : 0,
       buyerUsername: highestBidder?.user?.ingame_name || null,
       buyerQuantity: highestBidder?.quantity || 0,
+      // FIXED: hasBuyers should be true if price > 0 (price comes from buy orders)
+      hasBuyers: price > 0 || buyOrders.length > 0,
+      buyerCount: buyOrders.length,
+      sellerCount: sellOrders.length,
       // Seller data for investment cost calculations
       sellerPrice: sellOrders.length > 0 ? Math.min(...sellOrders.map((o: any) => o.platinum)) : 0,
       sellerUsername: lowestSeller?.user?.ingame_name || null,


### PR DESCRIPTION
Refactor Prime Set trading strategy to prioritize selling sets when individual parts lack buyers or are less profitable.

The previous logic incorrectly recommended selling individual parts even when some had no buyers, leading to a lower potential profit than selling the complete set (e.g., Bronco Prime). The updated formula now accurately identifies the most profitable strategy by considering the real sellable value of individual parts versus the set's market value, especially when parts are unsellable.

---
<a href="https://cursor.com/background-agent?bcId=bc-58d895f7-2808-4ec4-9a80-1ec96924bb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-58d895f7-2808-4ec4-9a80-1ec96924bb36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

